### PR TITLE
bindTo does not exist, this should be listenTo

### DIFF
--- a/src/marionette.formview.js
+++ b/src/marionette.formview.js
@@ -36,7 +36,7 @@
 
       if (!this.model) this.model = new Backbone.Model();
 
-      this.bindTo(this.model, 'change', this.changeFieldVal,this);
+      this.listenTo(this.model, 'change', this.changeFieldVal,this);
       if (this.data) this.model.set(this.data);
 
       //Attach Events to preexisting elements if we don't have a template


### PR DESCRIPTION
I had the following errors into the console:

```
Uncaught TypeError: Object [object Object] has no method 'bindTo' 
```

The following doc says that the "bindTo" function has probably renamed to "listenTo":

https://github.com/marionettejs/backbone.marionette/blob/master/docs/marionette.view.md#binding-to-view-events

So, by replacing the call to "bindTo" by "listenTo", I have no more errors.
